### PR TITLE
fix prevent unwanted access of site-editor.php

### DIFF
--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -23,6 +23,11 @@ if ( ! ( current_theme_supports( 'block-template-parts' ) || wp_is_block_theme()
 	wp_die( __( 'The theme you are currently using is not compatible with Full Site Editing.' ) );
 }
 
+$is_template_part_editor = isset( $_GET['postType'] ) && 'wp_template_part' === sanitize_key( $_GET['postType'] );
+if ( ! wp_is_block_theme() && ! $is_template_part_editor ) {
+	wp_die( __( 'The theme you are currently using is not compatible with the Site Editor.' ) );
+}
+
 /**
  * Do a server-side redirection if missing `postType` and `postId`
  * query args when visiting Site Editor.


### PR DESCRIPTION
Non block themes that support block-based template parts should only be allowed to access the `site-editor.php` page if the query parameter to access the template part editor is set correctly.

This fixes the issue that was found by @hellofromtonya here: https://github.com/WordPress/wordpress-develop/pull/3234#issuecomment-1247048286